### PR TITLE
Bengt/two tables

### DIFF
--- a/init-scripts/init.sql
+++ b/init-scripts/init.sql
@@ -17,6 +17,25 @@ CREATE INDEX idx_donations_timestamp ON donations(timestamp);
 
 CREATE INDEX idx_donations_address_timestamp ON donations(from_address, timestamp, amount_eth);
 
+CREATE TABLE IF NOT EXISTS donations_finalized (
+    id SERIAL PRIMARY KEY,
+    transaction_hash VARCHAR(66) UNIQUE NOT NULL,
+    from_address VARCHAR(42) NOT NULL,
+    amount_eth DECIMAL(20,18) NOT NULL,
+    namada_key VARCHAR(66) NOT NULL,
+    input_message VARCHAR,
+    message VARCHAR(100) NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    block_number BIGINT NOT NULL,
+    tx_index INTEGER NOT NULL
+);
+
+-- Add index for timestamp-based queries
+CREATE INDEX idx_donations_finalized_timestamp ON donations_finalized(timestamp);
+
+CREATE INDEX idx_donations_finalized_address_timestamp ON donations_finalized(from_address, timestamp, amount_eth);
+
 CREATE TABLE IF NOT EXISTS scraped_blocks (
     id SERIAL PRIMARY KEY,
     block_number BIGINT UNIQUE NOT NULL,
@@ -26,6 +45,16 @@ CREATE TABLE IF NOT EXISTS scraped_blocks (
 
 -- Create an index for faster block number lookups
 CREATE INDEX idx_block_number ON scraped_blocks(block_number);
+
+CREATE TABLE IF NOT EXISTS scraped_blocks_finalized (
+    id SERIAL PRIMARY KEY,
+    block_number BIGINT UNIQUE NOT NULL,
+    scraped_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    transactions_found INTEGER DEFAULT 0
+);
+
+-- Create an index for faster block number lookups
+CREATE INDEX idx_block_number_finalized ON scraped_blocks_finalized(block_number);
 
 DROP VIEW IF EXISTS donation_stats;
 
@@ -44,6 +73,65 @@ WITH running_address_totals AS (
             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
         ) as address_total
     FROM donations
+),
+eligible_amounts AS (
+    -- Calculate eligible amount for each transaction
+    SELECT 
+        id,
+        block_number,
+        tx_index,
+        CASE 
+            WHEN address_total >= 0.03 THEN 
+                LEAST(amount_eth, 0.3)
+            ELSE 0
+        END as eligible_amount
+    FROM running_address_totals
+),
+running_totals AS (
+    -- Calculate running sum of eligible amounts in strict transaction order
+    SELECT 
+        id,
+        block_number,
+        tx_index,
+        eligible_amount,
+        SUM(eligible_amount) OVER (
+            ORDER BY block_number, tx_index
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) as running_total
+    FROM eligible_amounts
+)
+SELECT
+    LEAST(
+        (SELECT MAX(running_total) FROM running_totals),
+        27.0
+    ) as eligible_total_eth,
+    cutoff.block_number as cutoff_block,
+    cutoff.tx_index as cutoff_tx_index
+FROM (
+    SELECT *
+    FROM running_totals
+    WHERE running_total >= 27
+    ORDER BY block_number, tx_index
+    LIMIT 1
+) cutoff;
+
+DROP VIEW IF EXISTS donation_stats_finalized;
+
+CREATE VIEW donation_stats_finalized AS
+WITH running_address_totals AS (
+    -- Calculate running totals per address in transaction order
+    SELECT 
+        id,
+        from_address,
+        amount_eth,
+        block_number,
+        tx_index,
+        SUM(amount_eth) OVER (
+            PARTITION BY from_address
+            ORDER BY block_number, tx_index
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) as address_total
+    FROM donations_finalized
 ),
 eligible_amounts AS (
     -- Calculate eligible amount for each transaction

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -14,9 +14,10 @@ export const pool = new Pool({
   database: process.env.POSTGRES_DB,
 });
 
-export async function saveTransaction(tx) {
+export async function saveTransaction(tx, finalized = false) {
+  const table = finalized ? "donations_finalized" : "donations";
   const query = `
-    INSERT INTO donations 
+    INSERT INTO ${table} 
     (transaction_hash, from_address, amount_eth, namada_key, input_message, message, block_number, tx_index, timestamp)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
     ON CONFLICT (transaction_hash) DO NOTHING
@@ -43,7 +44,7 @@ export async function saveTransaction(tx) {
   }
 }
 
-export async function saveTransactions(transactions) {
+export async function saveTransactions(transactions, finalized = false) {
   const BATCH_SIZE = 1000; // Adjust based on your needs
   const MAX_RETRIES = 5; // How often it retries per batch
 
@@ -76,8 +77,9 @@ export async function saveTransactions(transactions) {
           return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9})`;
         }).join(',');
 
+        const table = finalized ? "donations_finalized" : "donations";
         const query = `
-          INSERT INTO donations 
+          INSERT INTO ${table} 
           (transaction_hash, from_address, amount_eth, namada_key, input_message, message, block_number, tx_index, timestamp)
           VALUES ${placeholders}
           ON CONFLICT (transaction_hash) DO NOTHING
@@ -103,9 +105,10 @@ export async function saveTransactions(transactions) {
 }
 
 // New functions for block tracking
-export async function markBlockAsScraped(blockNumber, transactionsFound = 0) {
+export async function markBlockAsScraped(blockNumber, transactionsFound = 0, finalized = false) {
+  const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
-    INSERT INTO scraped_blocks 
+    INSERT INTO ${table}
     (block_number, transactions_found, scraped_at)
     VALUES ($1, $2, CURRENT_TIMESTAMP)
     ON CONFLICT (block_number) 
@@ -122,10 +125,11 @@ export async function markBlockAsScraped(blockNumber, transactionsFound = 0) {
   }
 }
 
-export async function isBlockScraped(blockNumber) {
+export async function isBlockScraped(blockNumber, finalized = false) {
+  const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
     SELECT EXISTS(
-      SELECT 1 FROM scraped_blocks WHERE block_number = $1
+      SELECT 1 FROM ${table} WHERE block_number = $1
     ) as exists
   `;
 
@@ -137,10 +141,11 @@ export async function isBlockScraped(blockNumber) {
   }
 }
 
-export async function getLastScrapedBlock() {
+export async function getLatestScrapedBlock(finalized = false) {
+  const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
     SELECT block_number 
-    FROM scraped_blocks 
+    FROM ${table}
     ORDER BY block_number DESC 
     LIMIT 1
   `;
@@ -149,7 +154,8 @@ export async function getLastScrapedBlock() {
     const result = await pool.query(query);
     return result.rows[0]?.block_number || 0; // Return 0 if no blocks have been scraped
   } catch(error) {
-    logError("Error getting last scraped block:", error);
+    console.error('Error getting latest scraped block:', error);
+    throw error;
   }
 }
 
@@ -186,13 +192,14 @@ export function extractNamadaKey(message) {
 }
 
 // Add a utility function to get block scraping stats
-export async function getBlockScrapingStats(blockNumber) {
+export async function getBlockScrapingStats(blockNumber, finalized = false) {
+  const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
     SELECT 
       block_number,
       transactions_found,
       scraped_at
-    FROM scraped_blocks 
+    FROM ${table} 
     WHERE block_number = $1
   `;
 
@@ -205,13 +212,14 @@ export async function getBlockScrapingStats(blockNumber) {
 }
 
 // Optional: Add a function to get recent scraping activity
-export async function getRecentScrapingActivity(limit = 10) {
+export async function getRecentScrapingActivity(limit = 10, finalized = false) {
+  const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
     SELECT 
       block_number,
       transactions_found,
       scraped_at
-    FROM scraped_blocks 
+    FROM ${table} 
     ORDER BY scraped_at DESC 
     LIMIT $1
   `;

--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -49,12 +49,13 @@ export async function getTransactionReceipt(txHash, retryCount = 0) {
   }
 }
 
-export const getBlockTransactions = async (blockNumber) => {
+export const getBlockTransactions = async (blockNumber, finalized = false) => {
   try {
+    const parameterOne = finalized ? "finalized" : `0x${blockNumber.toString(16)}`;
     const response = await axios.post(`${INFURA_BASE_URL}/${INFURA_API_KEY}`, {
       jsonrpc: "2.0",
       method: "eth_getBlockByNumber",
-      params: [`0x${blockNumber.toString(16)}`, true],
+      params: [parameterOne, true],
       id: 1,
     });
 
@@ -62,6 +63,11 @@ export const getBlockTransactions = async (blockNumber) => {
     if (!block) {
       log(`Block ${blockNumber}: doesn't exist.`);
       return null;
+    }
+
+    if (finalized && block.number > blockNumber) {
+      // If the block number is greater than the block number of the latest block, it means that we missed a block, so call the function again with the latest block number.
+      return await getBlockTransactions(blockNumber, false);
     }
 
     const transactions = block.transactions

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -1,4 +1,4 @@
-import { startScheduler } from "./scheduler.mjs";
+import { startScheduler, startSchedulerFinalized } from "./scheduler.mjs";
 import { getTransactions, decodeInputData, getLatestBlock } from "./etherscan.mjs";
 import {
   saveTransactions,
@@ -74,6 +74,7 @@ export async function initialize(skipInitialScrape = false) {
     log(`Using API endpoint: ${INFURA_BASE_URL}.`);
 
     startScheduler();
+    startSchedulerFinalized();
     
     isInitialized = true;
     log('Server initialization complete');

--- a/lib/scheduler.mjs
+++ b/lib/scheduler.mjs
@@ -67,3 +67,60 @@ export function startScheduler() {
     }
   });
 }
+
+let isRunningFinalized = false;
+
+export function startSchedulerFinalized() {
+  cron.schedule('*/12 * * * * *', async () => {
+    if(isRunning) {
+      log('Previous job is still running, skipping this round.');
+      return;
+    }
+
+    isRunning = true;
+
+    try {
+      const lastScrapedBlock = parseInt(await getLastScrapedBlock(true) || START_BLOCK);
+      const startBlock = lastScrapedBlock + 1;
+
+      const transactions = await getBlockTransactions(startBlock, true);
+
+      if(transactions !== null) {
+        // Decode input data filters out transactions that don't have input data, as well as failed txs
+        const decodedTransactions = decodeInputData(transactions);
+        const filteredTransactions = decodedTransactions.filter(tx =>
+          tx.decodedRawInput && 
+          extractNamadaKey(tx.decodedRawInput) !== ''
+        );
+
+        // Now add receipts
+        const transactionsWithReceipts = await Promise.all(
+          filteredTransactions
+            .map(async (tx) => {
+              const receipt = await getTransactionReceipt(tx.hash);
+              return addReceipt(tx, receipt);
+            })
+        );
+
+        const filteredTransactionsWithReceipts = transactionsWithReceipts.filter(tx => tx.txreceipt_status === '1' && tx.isError === '0');
+
+        // Save filtered transactions to database in bulk
+        if (filteredTransactionsWithReceipts.length > 0) {
+          await saveTransactions(filteredTransactionsWithReceipts, true);
+        }
+
+        log(`Block ${startBlock}: ${transactions.length} finalized transactions found, ${filteredTransactionsWithReceipts.length} saved.`);
+
+        await markBlockAsScraped(
+          startBlock,
+          filteredTransactionsWithReceipts.length,
+          true
+        );
+      }
+    } catch (error) {
+      logError('Error in cron job:', error);
+    } finally {
+      isRunning = false;
+    }
+  });
+}


### PR DESCRIPTION
@zenodeapp 

With these two logic tables, you will need an extra argument `isFinalized (bool)` in the api call to `checkDonation`

Then depending on whether you want to show them the finalized data or the latest one (not necesarily finalized) you choose that parameter. Same goes for the other endpoint in `calculate`.


## Changes

Duplicated tables for `donations`, `scraped_blocks` and `donations_stats`. Each now has a "finalized" version.

The scraping logic happens independently for the finalized version, and will act as the "state of truth". It will be lagging quite far behind the tip of the chain, but will ensure that no reorgs can happen to these blocks, and actual allocations should be done off these tables rather than their unfinalized counterparts.

