### PR TITLE
Improves raw input decoder (fixes #25)

### DIFF
--- a/lib/etherscan.mjs
+++ b/lib/etherscan.mjs
@@ -131,6 +131,8 @@ export const decodeInputData = (transactions) => {
         }
 
         // Try to decode as contract interaction
+        // TODO: not sure why this is present, I assume this could be removed - leaving it in here for now (comment by ZEN).
+        // If you remove this, make sure to also move the catch portion below.
         const decodedData = iface.parseTransaction({ data: tx.input });
         return {
           hash: tx.hash,
@@ -144,15 +146,31 @@ export const decodeInputData = (transactions) => {
           tx_index: tx.transactionIndex,
         };
       } catch (error) {
-        // Try to decode as UTF-8 if contract parsing fails
-        let decodedRawInput = 'Unable to decode raw input as UTF-8';
-        try {
-          const hexString = tx.input.slice(2);
-          const bytes = Buffer.from(hexString, 'hex');
-          decodedRawInput = bytes.toString('utf8');
-        } catch (decodeError) {
-          logError(`Error decoding raw input: ${decodeError.message}`);
-        }
+        const decodeRawInput = (input, maxIterations = 10) => {
+          let currentInput = input;
+        
+          for (let i = 0; i < maxIterations; i++) {
+            try {
+              // First remove '0x'-prefix and trim spaces.
+              currentInput = currentInput.replace(/^0x/, '').trim();
+
+              const bytes = Buffer.from(currentInput, 'hex');
+              const decoded = bytes.toString('utf8');
+              
+              // If we're not a hex value anymore, return it.
+              if (!/^[0-9a-fA-F]+$/.test(decoded)) return decoded;
+
+              // Continue if we're still a hex value
+              currentInput = decoded;
+            } catch (error) {
+              logError(`Error decoding raw input: ${error.message}`);
+              break;
+            }
+          }
+          
+          // Decoding failed if we got to this point.
+          return null;
+        };
 
         return {
           hash: tx.hash,
@@ -160,7 +178,7 @@ export const decodeInputData = (transactions) => {
           to: tx.to,
           value: ethers.formatEther(tx.value),
           rawInput: tx.input,
-          decodedRawInput,
+          decodedRawInput: decodeRawInput(tx.input) || 'Unable to decode raw input as UTF-8',
           timestamp: new Date(tx.timeStamp * 1000).toISOString(),
           block_number: tx.blockNumber,
           tx_index: tx.transactionIndex,

--- a/lib/etherscan.mjs
+++ b/lib/etherscan.mjs
@@ -151,8 +151,8 @@ export const decodeInputData = (transactions) => {
         
           for (let i = 0; i < maxIterations; i++) {
             try {
-              // First remove '0x'-prefix and trim spaces.
-              currentInput = currentInput.replace(/^0x/, '').trim();
+              // First trim spaces then remove '0x'- or '0X'-prefix(es).
+              currentInput = currentInput.trim().replace(/^(0x)+/i, '');
 
               const bytes = Buffer.from(currentInput, 'hex');
               const decoded = bytes.toString('utf8');


### PR DESCRIPTION
Fixes #25

- Decoding a hex value is now done in multiple iterations. This to auto-correct users who have encoded their addresses multiple times. It decodes the raw data until a non-hex value is found or when it reaches a depth of 10.
- Preceding and trailing spaces are trimmed.
- Accidentally adding multiple 0x's (or 0X's) won't be a problem.
- A hex without 0x will also not cause any problems.

Technically, people who had no 0x prefix double-encoded their tnam address. E.g. if you forgot 0x, a wallet like Rabby would auto-detect the 'hex' string as an UTF8 string. Which led to it getting double-encoded.