### PR TITLE
Added scraper flags --once and --all-etherscan-txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are currently two flags one could run the scraper with:
   
   > This flag will act as if `--once` is set as well.
 
-  This will get all transactions made between the given time frame (defined in the `.env`-file) without doing any tnam validation. This is useful if people made mistakes during the donor drop. Advised is to only run this 30 minutes after the donor drop ended (to prevent picking up transactions from `unfinalized` blocks).
+  This will get all transactions made in the given timeframe (defined in the `.env`-file) **without doing any tnam validation**. This is useful if people made mistakes during the donor drop and we want to give them the opportunity to link their tnams again (using https://github.com/zenodeapp/donor-drop-frontend/tree/with-link). Advised is to only run this command ~30 minutes after the donor drop ended to prevent picking up transactions from `unfinalized` blocks.
 
   > The resulting list of transactions will populate the `etherscan_transactions_all`-table instead of the usual `donations`-tables.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ node scraper.mjs
 >
 > For now you could use a separate systemctl service to run the scraper. See issue [#22](https://github.com/zenodeapp/donor-drop-backend/issues/22) for a template.
 
+#### 4.1. Scraper options
+
+There are currently two flags one could run the scraper with:
+
+- `--once`
+
+  ```
+  node scraper.mjs --once
+  ```
+
+  This will only let the scraper do a single run. Useful if you just want to fetch data once, without letting it check Etherscan/Infura every n-seconds.
+
+
+- `--all-etherscan-txs`
+
+  ```
+  node scraper.mjs --all-etherscan-txs
+  ```
+  
+  > This flag will act as if `--once` is set as well.
+
+  This will get all transactions made between the given time frame (defined in the `.env`-file) without doing any tnam validation. This is useful if people made mistakes during the donor drop. Advised is to only run this 30 minutes after the donor drop ended (to prevent picking up transactions from `unfinalized` blocks).
+
+  > The resulting list of transactions will populate the `etherscan_transactions_all`-table instead of the usual `donations`-tables.
+
 ## Testing
  
 The testing suite works as follows:

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -39,45 +39,60 @@ export async function saveTransaction(tx, finalized = false) {
       new Date(tx.timestamp),
     ];
     return await pool.query(query, values);
-  } catch(error) {
+  } catch (error) {
     logError("Error saving transaction:", error);
   }
 }
 
-export async function saveTransactions(transactions, finalized = false) {
+export async function saveTransactions(
+  transactions,
+  { finalized, bypassChecks }
+) {
   const BATCH_SIZE = 1000; // Adjust based on your needs
   const MAX_RETRIES = 5; // How often it retries per batch
 
   // Process in batches
   for (let i = 0; i < transactions.length; i += BATCH_SIZE) {
     const batch = transactions.slice(i, i + BATCH_SIZE);
-    
+
     let attempts = 0;
     let success = false;
 
-    while(!success && attempts < MAX_RETRIES) {
+    while (!success && attempts < MAX_RETRIES) {
       try {
         // Get messages for all transactions in this batch
         const messages = await getTemporaryMessages(batch.map((tx) => tx.from));
 
-        const values = batch.map((tx) => [
-          tx.hash.toLowerCase(),
-          tx.from,
-          tx.value,
-          extractNamadaKey(tx.decodedRawInput),
-          tx.decodedRawInput,
-          messages.get(tx.from.toLowerCase()) || getRandomMessage(), // Use message from Map if exists, otherwise random
-          BigInt(tx.block_number),
-          parseInt(tx.tx_index),
-          new Date(tx.timestamp)
-        ]).flat();
+        const values = batch
+          .map((tx) => [
+            tx.hash.toLowerCase(),
+            tx.from,
+            tx.value,
+            extractNamadaKey(tx.decodedRawInput),
+            tx.decodedRawInput,
+            messages.get(tx.from.toLowerCase()) || getRandomMessage(), // Use message from Map if exists, otherwise random
+            BigInt(tx.block_number),
+            parseInt(tx.tx_index),
+            new Date(tx.timestamp),
+          ])
+          .flat();
 
-        const placeholders = batch.map((_, j) => {
-          const offset = j * 9; // Updated to 9 parameters
-          return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9})`;
-        }).join(',');
+        const placeholders = batch
+          .map((_, j) => {
+            const offset = j * 9; // Updated to 9 parameters
+            return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${
+              offset + 4
+            }, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${
+              offset + 8
+            }, $${offset + 9})`;
+          })
+          .join(",");
 
-        const table = finalized ? "donations_finalized" : "donations";
+        const table = bypassChecks
+          ? "etherscan_transactions_all"
+          : finalized
+          ? "donations_finalized"
+          : "donations";
         const query = `
           INSERT INTO ${table} 
           (transaction_hash, from_address, amount_eth, namada_key, input_message, message, block_number, tx_index, timestamp)
@@ -89,14 +104,17 @@ export async function saveTransactions(transactions, finalized = false) {
         await pool.query(query, values);
 
         success = true;
-      } catch(error) {
+      } catch (error) {
         attempts++;
 
         if (attempts < MAX_RETRIES) {
           logError(`Error processing batch (Attempt ${attempts}):`, error);
-          await new Promise(resolve => setTimeout(resolve, 1000)); // short delay introduced before it attempts again.
+          await new Promise((resolve) => setTimeout(resolve, 1000)); // short delay introduced before it attempts again.
         } else {
-          logError(`Error processing batch after ${MAX_RETRIES} attempts:`, error);
+          logError(
+            `Error processing batch after ${MAX_RETRIES} attempts:`,
+            error
+          );
           throw error;
         }
       }
@@ -105,7 +123,11 @@ export async function saveTransactions(transactions, finalized = false) {
 }
 
 // New functions for block tracking
-export async function markBlockAsScraped(blockNumber, transactionsFound = 0, finalized = false) {
+export async function markBlockAsScraped(
+  blockNumber,
+  transactionsFound = 0,
+  finalized = false
+) {
   const table = finalized ? "scraped_blocks_finalized" : "scraped_blocks";
   const query = `
     INSERT INTO ${table}
@@ -120,7 +142,7 @@ export async function markBlockAsScraped(blockNumber, transactionsFound = 0, fin
 
   try {
     return pool.query(query, [blockNumber, transactionsFound]);
-  } catch(error) {
+  } catch (error) {
     logError("Error marking block as scraped:", error);
   }
 }
@@ -136,7 +158,7 @@ export async function isBlockScraped(blockNumber, finalized = false) {
   try {
     const result = await pool.query(query, [blockNumber]);
     return result.rows[0].exists;
-  } catch(error) {
+  } catch (error) {
     logError("Error checking if block is scraped:", error);
   }
 }
@@ -153,8 +175,8 @@ export async function getLatestScrapedBlock(finalized = false) {
   try {
     const result = await pool.query(query);
     return result.rows[0]?.block_number || 0; // Return 0 if no blocks have been scraped
-  } catch(error) {
-    logError('Error getting latest scraped block:', error);
+  } catch (error) {
+    logError("Error getting latest scraped block:", error);
     throw error;
   }
 }
@@ -206,7 +228,7 @@ export async function getBlockScrapingStats(blockNumber, finalized = false) {
   try {
     const result = await pool.query(query, [blockNumber]);
     return result.rows[0];
-  } catch(error) {
+  } catch (error) {
     logError(`Error fetching scraping stats for block ${blockNumber}:`, error);
   }
 }
@@ -227,8 +249,8 @@ export async function getRecentScrapingActivity(limit = 10, finalized = false) {
   try {
     const result = await pool.query(query, [limit]);
     return result.rows;
-  } catch(error) {
-    logError(`Error fetching recent scraping activity:`, error)
+  } catch (error) {
+    logError(`Error fetching recent scraping activity:`, error);
   }
 }
 
@@ -278,7 +300,7 @@ export async function getTemporaryMessage(from) {
     }
 
     return undefined;
-  } catch(error) {
+  } catch (error) {
     logError("Error getting temporary message:", error, from);
     return undefined;
   }
@@ -291,23 +313,21 @@ export async function getTemporaryMessages(fromAddresses) {
     WHERE lower(from_address) = ANY($1)
     AND created_at > NOW() - INTERVAL '10 minutes'
   `;
-    
-    // Convert addresses to lowercase for consistent matching
-    const lowerAddresses = fromAddresses.map(addr => addr.toLowerCase());
+
+  // Convert addresses to lowercase for consistent matching
+  const lowerAddresses = fromAddresses.map((addr) => addr.toLowerCase());
 
   try {
     const result = await pool.query(query, [lowerAddresses]);
 
     // Convert results to a Map for easy lookup
-    return new Map(
-      result.rows.map(row => [row.from_address, row.message])
-    );
-  } catch(error) {
+    return new Map(result.rows.map((row) => [row.from_address, row.message]));
+  } catch (error) {
     logError("Error getting temporary messages:", error, fromAddresses);
     return new Map();
   }
 }
 
-pool.on('error', async (error, _) => {
-  logError('Unexpected error on pool connection:', error)
+pool.on("error", async (error, _) => {
+  logError("Unexpected error on pool connection:", error);
 });

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -46,7 +46,7 @@ export async function saveTransaction(tx, finalized = false) {
 
 export async function saveTransactions(
   transactions,
-  { finalized, writeToEtherscanTable }
+  { finalized, allEtherscanTxs }
 ) {
   const BATCH_SIZE = 1000; // Adjust based on your needs
   const MAX_RETRIES = 5; // How often it retries per batch
@@ -88,7 +88,7 @@ export async function saveTransactions(
           })
           .join(",");
 
-        const table = writeToEtherscanTable
+        const table = allEtherscanTxs
           ? "etherscan_transactions_all"
           : finalized
           ? "donations_finalized"

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -46,7 +46,7 @@ export async function saveTransaction(tx, finalized = false) {
 
 export async function saveTransactions(
   transactions,
-  { finalized, bypassChecks }
+  { finalized, writeToEtherscanTable }
 ) {
   const BATCH_SIZE = 1000; // Adjust based on your needs
   const MAX_RETRIES = 5; // How often it retries per batch
@@ -88,7 +88,7 @@ export async function saveTransactions(
           })
           .join(",");
 
-        const table = bypassChecks
+        const table = writeToEtherscanTable
           ? "etherscan_transactions_all"
           : finalized
           ? "donations_finalized"

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -140,7 +140,7 @@ async function performInitialFinalizedScrape(initOptions) {
 
 async function processAndSaveTransactions(
   transactions,
-  { finalized, addReceipts, bypassTnamValidation }
+  { finalized, addReceipts, bypassTnamValidation, allEtherscanTxs }
 ) {
   const decodedTransactions = decodeInputData(transactions);
   let filteredTransactions = !bypassTnamValidation
@@ -162,7 +162,7 @@ async function processAndSaveTransactions(
   if (filteredTransactions.length > 0) {
     await saveTransactions(filteredTransactions, {
       finalized,
-      bypassTnamValidation,
+      allEtherscanTxs,
     });
   }
 

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -52,14 +52,15 @@ async function performInitialScrape(initOptions) {
         ...{ finalized: false, addReceipts: false },
       });
 
-    if (!initOptions.once) {
-      // The block to mark should either be the last block with a valid transaction or the latest block
-      // minus a margin. This to make sure we don't miss any transactions due to now using multiple endpoints.
-      let blockToMark = Math.max(
-        lastSeenBlock,
-        Math.max(latestBlock - SAFETY_LAG, 1)
-      );
+    // The block to mark should either be the last block with a valid transaction or the latest block
+    // minus a margin. This to make sure we don't miss any transactions due to now using multiple endpoints.
+    let blockToMark = Math.max(
+      lastSeenBlock,
+      Math.max(latestBlock - SAFETY_LAG, 1)
+    );
 
+    // Don't mark blocks if --all-etherscan-txs is set
+    if (!initOptions.allEtherscanTxs) {
       // Mark the block scraped with the amount of transactions found.
       await markBlockAsScraped(blockToMark, filteredTransactions.length);
     }
@@ -129,7 +130,8 @@ async function performInitialFinalizedScrape(initOptions) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
-    if (!initOptions.once) {
+    // Don't mark blocks if --all-etherscan-txs is set
+    if (!initOptions.allEtherscanTxs) {
       await markBlockAsScraped(latestBlock, transactionCount, true);
     }
   } catch (error) {

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -27,7 +27,7 @@ const SAFETY_LAG = 50;
 // TODO: likely this can be removed in the current setting.
 let isInitialized = false;
 
-async function performInitialScrape() {
+async function performInitialScrape(initOptions) {
   try {
     const latestBlock = (await getLatestBlock()) || 1;
     if (latestBlock < START_BLOCK) {
@@ -47,24 +47,29 @@ async function performInitialScrape() {
     );
 
     const { filteredTransactions, lastSeenBlock } =
-      await processAndSaveTransactions(transactions);
+      await processAndSaveTransactions(transactions, {
+        ...initOptions,
+        ...{ finalized: false, addReceipts: false },
+      });
 
-    // The block to mark should either be the last block with a valid transaction or the latest block
-    // minus a margin. This to make sure we don't miss any transactions due to now using multiple endpoints.
-    let blockToMark = Math.max(
-      lastSeenBlock,
-      Math.max(latestBlock - SAFETY_LAG, 1)
-    );
+    if (!initOptions.once) {
+      // The block to mark should either be the last block with a valid transaction or the latest block
+      // minus a margin. This to make sure we don't miss any transactions due to now using multiple endpoints.
+      let blockToMark = Math.max(
+        lastSeenBlock,
+        Math.max(latestBlock - SAFETY_LAG, 1)
+      );
 
-    // Mark the block scraped with the amount of transactions found.
-    await markBlockAsScraped(blockToMark, filteredTransactions.length);
+      // Mark the block scraped with the amount of transactions found.
+      await markBlockAsScraped(blockToMark, filteredTransactions.length);
+    }
   } catch (error) {
     logError("Error during initial scrape:", error);
     throw error;
   }
 }
 
-async function performInitialFinalizedScrape() {
+async function performInitialFinalizedScrape(initOptions) {
   try {
     const latestBlock = (await getLatestFinalizedBlock()) || 1;
     if (latestBlock < START_BLOCK) {
@@ -91,7 +96,7 @@ async function performInitialFinalizedScrape() {
 
     const { filteredTransactions } = await processAndSaveTransactions(
       transactions,
-      true
+      { ...initOptions, ...{ finalized: true, addReceipts: false } }
     );
 
     transactionCount = transactionCount + filteredTransactions.length;
@@ -110,8 +115,10 @@ async function performInitialFinalizedScrape() {
 
       const { filteredTransactions } = await processAndSaveTransactions(
         transactions,
-        true,
-        true
+        {
+          ...initOptions,
+          ...{ finalized: false, addReceipts: true },
+        }
       );
 
       transactionCount = transactionCount + filteredTransactions.length;
@@ -131,13 +138,15 @@ async function performInitialFinalizedScrape() {
 
 async function processAndSaveTransactions(
   transactions,
-  finalized = false,
-  addReceipts = false
+  { finalized, addReceipts, bypassChecks }
 ) {
   const decodedTransactions = decodeInputData(transactions);
-  let filteredTransactions = decodedTransactions.filter(
-    (tx) => tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ""
-  );
+  let filteredTransactions = !initOptions.bypassChecks
+    ? decodedTransactions.filter(
+        (tx) =>
+          tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ""
+      )
+    : decodedTransactions;
 
   // Receipts get added in batches. 4000 credits / 80 per call = 50 request per sec as the max for Infura.
   if (addReceipts) {
@@ -149,7 +158,7 @@ async function processAndSaveTransactions(
   );
 
   if (filteredTransactions.length > 0) {
-    await saveTransactions(filteredTransactions, finalized);
+    await saveTransactions(filteredTransactions, { finalized, bypassChecks });
   }
 
   log(
@@ -166,7 +175,7 @@ async function processAndSaveTransactions(
   };
 }
 
-export async function initialize(skipInitialScrape = false) {
+export async function initialize(initOptions) {
   if (isInitialized) {
     log("Server already initialized, skipping...");
     return;
@@ -176,24 +185,23 @@ export async function initialize(skipInitialScrape = false) {
   log(`Address configured to: ${ADDRESS}`);
   log(`Start block: ${START_BLOCK}`);
   try {
-    // Only perform initial scrape if not skipped
-    if (!skipInitialScrape) {
-      log("Performing initial scrape...");
-      await performInitialScrape();
-      console.log();
-      await performInitialFinalizedScrape();
-      log("Initial scrape complete!");
-      console.log();
+    log("Performing initial scrape...");
+    await performInitialScrape(initOptions);
+    console.log();
+    await performInitialFinalizedScrape(initOptions);
+    log("Initial scrape complete!");
+    console.log();
+
+    // Only start the scheduler if the scraper isn't run with the --once flag
+    if (!initOptions.once) {
+      log("Starting schedulers for ongoing updates...");
+      log(`Using API endpoint: ${INFURA_BASE_URL}.`);
+
+      startScheduler(initOptions);
+      startSchedulerFinalized(initOptions);
     } else {
-      log("Skipping initial scrape...");
+      process.exit(0);
     }
-
-    // Always start the scheduler
-    log("Starting schedulers for ongoing updates...");
-    log(`Using API endpoint: ${INFURA_BASE_URL}.`);
-
-    startScheduler();
-    startSchedulerFinalized();
 
     isInitialized = true;
     log("Server initialization complete.");

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -193,7 +193,7 @@ export async function initialize(initOptions) {
     log("Performing initial scrape...");
     await performInitialScrape(initOptions);
 
-    if (!initOptions.writeToEtherscanTable) {
+    if (!initOptions.allEtherscanTxs) {
       console.log();
       await performInitialFinalizedScrape(initOptions);
     }

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -140,10 +140,10 @@ async function performInitialFinalizedScrape(initOptions) {
 
 async function processAndSaveTransactions(
   transactions,
-  { finalized, addReceipts, bypassChecks }
+  { finalized, addReceipts, bypassTnamValidation }
 ) {
   const decodedTransactions = decodeInputData(transactions);
-  let filteredTransactions = !bypassChecks
+  let filteredTransactions = !bypassTnamValidation
     ? decodedTransactions.filter(
         (tx) =>
           tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ""
@@ -160,7 +160,10 @@ async function processAndSaveTransactions(
   );
 
   if (filteredTransactions.length > 0) {
-    await saveTransactions(filteredTransactions, { finalized, bypassChecks });
+    await saveTransactions(filteredTransactions, {
+      finalized,
+      bypassTnamValidation,
+    });
   }
 
   log(
@@ -190,7 +193,7 @@ export async function initialize(initOptions) {
     log("Performing initial scrape...");
     await performInitialScrape(initOptions);
 
-    if (!initOptions.onlyEtherscan) {
+    if (!initOptions.writeToEtherscanTable) {
       console.log();
       await performInitialFinalizedScrape(initOptions);
     }

--- a/lib/init.mjs
+++ b/lib/init.mjs
@@ -117,7 +117,7 @@ async function performInitialFinalizedScrape(initOptions) {
         transactions,
         {
           ...initOptions,
-          ...{ finalized: false, addReceipts: true },
+          ...{ finalized: true, addReceipts: true },
         }
       );
 
@@ -129,7 +129,9 @@ async function performInitialFinalizedScrape(initOptions) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
-    await markBlockAsScraped(latestBlock, transactionCount, true);
+    if (!initOptions.once) {
+      await markBlockAsScraped(latestBlock, transactionCount, true);
+    }
   } catch (error) {
     logError("Error during initial scrape (finalized):", error);
     throw error;
@@ -141,7 +143,7 @@ async function processAndSaveTransactions(
   { finalized, addReceipts, bypassChecks }
 ) {
   const decodedTransactions = decodeInputData(transactions);
-  let filteredTransactions = !initOptions.bypassChecks
+  let filteredTransactions = !bypassChecks
     ? decodedTransactions.filter(
         (tx) =>
           tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ""
@@ -187,8 +189,12 @@ export async function initialize(initOptions) {
   try {
     log("Performing initial scrape...");
     await performInitialScrape(initOptions);
-    console.log();
-    await performInitialFinalizedScrape(initOptions);
+
+    if (!initOptions.onlyEtherscan) {
+      console.log();
+      await performInitialFinalizedScrape(initOptions);
+    }
+
     log("Initial scrape complete!");
     console.log();
 
@@ -197,8 +203,8 @@ export async function initialize(initOptions) {
       log("Starting schedulers for ongoing updates...");
       log(`Using API endpoint: ${INFURA_BASE_URL}.`);
 
-      startScheduler(initOptions);
-      startSchedulerFinalized(initOptions);
+      startScheduler();
+      startSchedulerFinalized();
     } else {
       process.exit(0);
     }

--- a/lib/scheduler.mjs
+++ b/lib/scheduler.mjs
@@ -1,6 +1,4 @@
-import {
-  decodeInputData,
-} from "./etherscan.mjs";
+import { decodeInputData } from "./etherscan.mjs";
 import {
   saveTransactions,
   markBlockAsScraped,
@@ -12,16 +10,16 @@ import { START_BLOCK, VERBOSE_LOGGING } from "../_variables.mjs";
 import { log, logError } from "../helpers.mjs";
 import { getBlockTransactions, addReceiptsTo } from "./infura.mjs";
 
-let scheduler = { 
+let scheduler = {
   busy: false,
   queryFinalized: false,
-  interval: parseInt(process.env.SCRAPER_SCHEDULER_INTERVAL || 1)
+  interval: parseInt(process.env.SCRAPER_SCHEDULER_INTERVAL || 1),
 };
 
-let schedulerFinalized = { 
+let schedulerFinalized = {
   busy: false,
   queryFinalized: true,
-  interval: parseInt(process.env.SCRAPER_SCHEDULER_FINALIZED_INTERVAL || 12)
+  interval: parseInt(process.env.SCRAPER_SCHEDULER_FINALIZED_INTERVAL || 12),
 };
 
 export function startScheduler() {
@@ -37,9 +35,13 @@ export function startSchedulerFinalized() {
 }
 
 async function scrapeBlockchain(_scheduler) {
-  if(_scheduler.busy) {
-    if(VERBOSE_LOGGING)
-      log(`Previous job ${(_scheduler.queryFinalized ? '(finalized) ' : '')}is still running, skipping this round.`);
+  if (_scheduler.busy) {
+    if (VERBOSE_LOGGING)
+      log(
+        `Previous job ${
+          _scheduler.queryFinalized ? "(finalized) " : ""
+        }is still running, skipping this round.`
+      );
     return;
   }
 
@@ -47,30 +49,44 @@ async function scrapeBlockchain(_scheduler) {
 
   const { queryFinalized } = _scheduler;
   try {
-    const lastScrapedBlock = parseInt(await getLatestScrapedBlock(queryFinalized));
-    const startBlock = lastScrapedBlock === 0 ? START_BLOCK : lastScrapedBlock + 1;
+    const lastScrapedBlock = parseInt(
+      await getLatestScrapedBlock(queryFinalized)
+    );
+    const startBlock =
+      lastScrapedBlock === 0 ? START_BLOCK : lastScrapedBlock + 1;
 
     const transactions = await getBlockTransactions(startBlock, queryFinalized);
 
     // No block found
-    if(transactions === null) return;
+    if (transactions === null) return;
 
     // Decode input data filters out transactions that don't have input data, as well as failed txs
     const filteredTransactions = decodeInputData(transactions).filter(
-      tx => tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ''
+      (tx) => tx.decodedRawInput && extractNamadaKey(tx.decodedRawInput) !== ""
     );
 
     // Now add receipts. 4000 / 80 = 50 request per sec is the max for infura, but lowered it to play it safe.
-    const transactionsWithReceipts = await addReceiptsTo(filteredTransactions, 30);
+    const transactionsWithReceipts = await addReceiptsTo(
+      filteredTransactions,
+      30
+    );
 
     // Filter receipts
-    const filteredTransactionsWithReceipts = transactionsWithReceipts.filter(tx =>
-      tx.txreceipt_status === '1' && tx.isError === '0');
+    const filteredTransactionsWithReceipts = transactionsWithReceipts.filter(
+      (tx) => tx.txreceipt_status === "1" && tx.isError === "0"
+    );
 
     // Save filtered transactions to database in bulk
-    if (filteredTransactionsWithReceipts.length > 0) await saveTransactions(filteredTransactionsWithReceipts, queryFinalized);
+    if (filteredTransactionsWithReceipts.length > 0)
+      await saveTransactions(filteredTransactionsWithReceipts, {
+        finalized: queryFinalized,
+      });
 
-    log(`Block ${startBlock}: ${transactions.length} ${queryFinalized ? 'finalized ' : ""}transactions found, ${filteredTransactionsWithReceipts.length} saved.`);
+    log(
+      `Block ${startBlock}: ${transactions.length} ${
+        queryFinalized ? "finalized " : ""
+      }transactions found, ${filteredTransactionsWithReceipts.length} saved.`
+    );
 
     await markBlockAsScraped(
       startBlock,
@@ -78,7 +94,7 @@ async function scrapeBlockchain(_scheduler) {
       queryFinalized
     );
   } catch (error) {
-    logError('Error in cron job:', error);
+    logError("Error in cron job:", error);
   } finally {
     _scheduler.busy = false;
   }

--- a/scraper.mjs
+++ b/scraper.mjs
@@ -4,9 +4,14 @@ import { log, logError } from "./helpers.mjs";
 
 const PORT = process.env.SCRAPER_PORT || 3000;
 
+// Gets all given arguments if there are any.
 const args = process.argv.slice(2);
+
+// --once will only scrape a single time, without running any schedulers.
 const once = args.includes("--once");
-const allEtherscanTxs = args.includes("--all-etherscan-txs"); // This will also consider 'once' to be set to 'true'
+
+// --all-etherscan-txs will make sure we skip tnam validation, only scrape using etherscan, write to the etherscan_transactions_all table and considers '--once' to be set.
+const allEtherscanTxs = args.includes("--all-etherscan-txs");
 
 createServer(async (req, res) => {
   res.statusCode = 200;
@@ -23,7 +28,7 @@ createServer(async (req, res) => {
     await initialize({
       once: allEtherscanTxs || once,
       allEtherscanTxs,
-      bypassTnamValidation: allEtherscanTxs, // currently allEtherscanTxs will make sure we write to the etherscan_transactions_all table.
+      bypassTnamValidation: allEtherscanTxs,
     });
   } catch (error) {
     logError("Failed to initialize scraper:", error);

--- a/scraper.mjs
+++ b/scraper.mjs
@@ -6,7 +6,7 @@ const PORT = process.env.SCRAPER_PORT || 3000;
 
 const args = process.argv.slice(2);
 const once = args.includes("--once");
-const bypassChecks = args.includes("--bypass-checks"); // This will also consider 'once' to be set to 'true'
+const bypassTnamValidation = args.includes("--bypass-tnam-validation"); // This will also consider 'once' to be set to 'true'
 
 createServer(async (req, res) => {
   res.statusCode = 200;
@@ -21,9 +21,9 @@ createServer(async (req, res) => {
   // Initialize server
   try {
     await initialize({
-      once: bypassChecks || once,
-      bypassChecks,
-      onlyEtherscan: bypassChecks, // currently bypassing checks will only use the Etherscan API
+      once: bypassTnamValidation || once,
+      bypassTnamValidation,
+      writeToEtherscanTable: bypassTnamValidation, // currently bypassTnamValidation will make sure we write to the etherscan_transactions_all table.
     });
   } catch (error) {
     logError("Failed to initialize scraper:", error);

--- a/scraper.mjs
+++ b/scraper.mjs
@@ -6,7 +6,7 @@ const PORT = process.env.SCRAPER_PORT || 3000;
 
 const args = process.argv.slice(2);
 const once = args.includes("--once");
-const bypassTnamValidation = args.includes("--bypass-tnam-validation"); // This will also consider 'once' to be set to 'true'
+const allEtherscanTxs = args.includes("--all-etherscan-txs"); // This will also consider 'once' to be set to 'true'
 
 createServer(async (req, res) => {
   res.statusCode = 200;
@@ -21,9 +21,9 @@ createServer(async (req, res) => {
   // Initialize server
   try {
     await initialize({
-      once: bypassTnamValidation || once,
-      bypassTnamValidation,
-      writeToEtherscanTable: bypassTnamValidation, // currently bypassTnamValidation will make sure we write to the etherscan_transactions_all table.
+      once: allEtherscanTxs || once,
+      allEtherscanTxs,
+      bypassTnamValidation: allEtherscanTxs, // currently allEtherscanTxs will make sure we write to the etherscan_transactions_all table.
     });
   } catch (error) {
     logError("Failed to initialize scraper:", error);

--- a/scraper.mjs
+++ b/scraper.mjs
@@ -4,6 +4,10 @@ import { log, logError } from "./helpers.mjs";
 
 const PORT = process.env.SCRAPER_PORT || 3000;
 
+const args = process.argv.slice(2);
+const once = args.includes("--once");
+const bypassChecks = args.includes("--bypass-checks"); // This will also consider 'once' to be set to 'true'
+
 createServer(async (req, res) => {
   res.statusCode = 200;
   res.end();
@@ -16,7 +20,7 @@ createServer(async (req, res) => {
 
   // Initialize server
   try {
-    await initialize();
+    await initialize({ once: bypassChecks || once, bypassChecks });
   } catch (error) {
     logError("Failed to initialize scraper:", error);
   }

--- a/scraper.mjs
+++ b/scraper.mjs
@@ -20,7 +20,11 @@ createServer(async (req, res) => {
 
   // Initialize server
   try {
-    await initialize({ once: bypassChecks || once, bypassChecks });
+    await initialize({
+      once: bypassChecks || once,
+      bypassChecks,
+      onlyEtherscan: bypassChecks, // currently bypassing checks will only use the Etherscan API
+    });
   } catch (error) {
     logError("Failed to initialize scraper:", error);
   }


### PR DESCRIPTION
This allows the scraper to get run with the following flags:

- `--once`: This will only run the scraper a single time and won't run the scheduler(s).
- `--all-etherscan-txs`: This will get all transactions made between the given time frame without doing any tnam validation. This will insert these transactions to the `etherscan_transactions_all` table instead of the `donations`-tables. This considers the flag `--once` to be added. 

There's no logic for checking whether the transactions you pick up with the flag `--all-etherscan-txs` are finalized, so make sure to only run it with that flag approx. 30 minutes after the Donor Drop ended.

Fixes #28.