### PR TITLE
Added (Interactive) wizard for exporting results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ collegeproject-c9550-c919afa91c6b.json
 # lock files
 package-lock.json
 yarn.lock
+
+# Results
+/output

--- a/helpers.mjs
+++ b/helpers.mjs
@@ -47,7 +47,7 @@ const askUser = (message, defaultYes = false, tabs = 0) => {
   });
 };
 
-const createCsv = (columns, rows) => {
+const createCsvContent = (columns, rows) => {
   let result = columns.join(",") + "\n";
   rows.forEach((row) => {
     result += columns.map((col) => row[col] ?? "").join(",") + "\n";
@@ -56,4 +56,4 @@ const createCsv = (columns, rows) => {
   return result;
 };
 
-export { log, logError, createCsv, askUser };
+export { log, logError, askUser, createCsvContent };

--- a/helpers.mjs
+++ b/helpers.mjs
@@ -1,13 +1,59 @@
-const prettyTimestamp = () => (
-  new Date().toISOString().replace('T', ' ').split('.')[0]);
+import readline from "readline";
+
+const prettyTimestamp = () =>
+  new Date().toISOString().replace("T", " ").split(".")[0];
 
 const log = (...args) => {
   console.log(`[${prettyTimestamp()}]`, ...args);
-}
+};
 
 const logError = (...args) => {
   console.error(`[${prettyTimestamp()}]`, ...args);
-}
+};
 
+const askUser = (message, defaultYes = false, tabs = 0) => {
+  const indent = " ".repeat(tabs * 2);
 
-export { log, logError };
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    const ask = () => {
+      rl.question(
+        `${indent}${message} ${defaultYes ? "(Y/n)" : "(y/N)"} `,
+        (answer) => {
+          if (answer === "") {
+            rl.close();
+            resolve(defaultYes);
+          } else if (answer.toLowerCase() === "y") {
+            rl.close();
+            resolve(true);
+          } else if (answer.toLowerCase() === "n") {
+            rl.close();
+            resolve(false);
+          } else {
+            console.log(
+              `${indent}❌ Invalid input. Please enter 'y' for Yes or 'n' for No.`
+            );
+            ask(); // Ask again without closing
+          }
+        }
+      );
+    };
+
+    ask();
+  });
+};
+
+const createCsv = (columns, rows) => {
+  let result = columns.join(",") + "\n";
+  rows.forEach((row) => {
+    result += columns.map((col) => row[col] ?? "").join(",") + "\n";
+  });
+
+  return result;
+};
+
+export { log, logError, createCsv, askUser };

--- a/result.mjs
+++ b/result.mjs
@@ -1,0 +1,295 @@
+import { mkdir, rm, writeFile } from "fs/promises";
+import { pool } from "./lib/db.mjs";
+import { askUser, createCsv } from "./helpers.mjs";
+
+// Arguments
+// TODO: issue #15 will make the args --min-eth-per-address and --max-eth-per-address obsolete.
+const clean = process.argv.includes("--clean");
+const excludeEligibles = process.argv.includes("--exclude-eligibles");
+const excludeAboveCap = process.argv.includes("--exclude-above-cap");
+const excludeNotInDb = process.argv.includes("--exclude-not-in-db");
+const minEthPerAddress = process.argv.includes("--min-eth-per-address")
+  ? parseFloat(process.argv[process.argv.indexOf("--min-eth-per-address") + 1])
+  : 0.03;
+const maxEthPerAddress = process.argv.includes("--max-eth-per-address")
+  ? parseFloat(process.argv[process.argv.indexOf("--max-eth-per-address") + 1])
+  : 0.3;
+
+// Queries
+const queries = {};
+
+if (!excludeEligibles)
+  queries.eligibles = `SELECT from_address AS eth_address, tnam AS nam_address, eligible_amount AS eth_amount, suggested_nam AS nam_amount FROM private_result_eligible_addresses_finalized_in_db`;
+
+if (!excludeAboveCap)
+  queries.above_cap = `SELECT from_address AS eth_address, tnam AS nam_address, eligible_above_cap AS eth_amount, suggested_nam AS nam_amount FROM private_result_above_cap_addresses_in_db`;
+
+if (!excludeNotInDb)
+  queries.not_in_db = `SELECT from_address AS eth_address, tnam AS nam_address, total_eth AS eth_amount, suggested_nam AS nam_amount, sig_hash FROM private_result_addresses_not_in_db`;
+
+const main = async () => {
+  console.log();
+  console.log(`Arguments:`);
+  console.log(
+    `--exclude-eligibles: ${excludeEligibles.toString()} [exclude eligible users]`
+  );
+  console.log(
+    `--exclude-above-cap: ${excludeAboveCap.toString()} [exclude users who donated after the cap]`
+  );
+  console.log(
+    `--exclude-not-in-db: ${excludeNotInDb.toString()} [exclude users who were initially not included]`
+  );
+  console.log(
+    `--min-eth-per-address: ${minEthPerAddress.toString()} [default: 0.03]`
+  );
+  console.log(
+    `--max-eth-per-address: ${maxEthPerAddress.toString()} [default: 0.3]`
+  );
+  console.log(
+    `--clean: ${clean.toString()} [discards ./output before exporting results]`
+  );
+  console.log();
+
+  console.log(
+    `This will export the raw and final results in .csv, .json, and .proposal.json-format.`
+  );
+  const response = await askUser("Do you wish to continue?");
+
+  if (!response) {
+    console.log("Operation cancelled.");
+    process.exit(0); // Exit the script if the user does not confirm
+  }
+
+  console.log();
+
+  // Remove ./output folder if --clean argument is set
+  if (clean) {
+    try {
+      // Remove the entire 'output' folder and its contents
+      await rm("./output", { recursive: true, force: true });
+      console.log("🗑️   Removed ./output.");
+    } catch (e) {
+      console.error("🗑️   Error removing ./output :", error);
+    }
+  }
+
+  // Ensure ./output directory exists
+  await mkdir("./output", { recursive: true });
+
+  // Create raw exports and collect all entries for later use
+  console.log("💾  Saving raw results...");
+  const allRows = [];
+  await Promise.all(
+    Object.entries(queries).map(async ([key, query]) => {
+      const data = await createRawResults(query, `_raw_${key}`);
+
+      if (data) allRows.push(...data);
+    })
+  );
+
+  // Create final results
+  console.log("💾  Saving final results...");
+  const results = await createFinalResults(allRows);
+
+  showResults(results);
+
+  // Close DB connection
+  await pool.end();
+};
+
+const showResults = (data) => {
+  console.log();
+  console.log("🧮 Export finished successfully!");
+  console.log(`    👤 ${data.length} participants`);
+
+  let ethTotal = 0;
+  let namTotal = 0;
+
+  for (const row of data) {
+    ethTotal += parseFloat(row.eth_amount);
+    namTotal += row.nam_amount;
+  }
+  console.log(
+    `    💰 ${ethTotal.toFixed(6)} ETH donated (rounded by 6 decimals)`
+  );
+  console.log(`    👛 ${namTotal} NAM (rounded)`);
+};
+
+// Exports raw data and returns the rows as an object for later use
+const createRawResults = async (query, fileName) => {
+  try {
+    const result = await pool.query(query);
+
+    if (!result.rows.length) {
+      console.log(`No data found for ${fileName}.`);
+      return [];
+    }
+
+    const columns = result.fields.map((field) => field.name);
+
+    // raw .csv export
+    const csvFilePath = `./output/${fileName}.csv`;
+    await writeFile(csvFilePath, createCsv(columns, result.rows), "utf8");
+    console.log(`    Exported ${csvFilePath}.`);
+
+    // raw .json export
+    const jsonFilePath = `./output/${fileName}.json`;
+    await writeFile(jsonFilePath, JSON.stringify(result.rows, null, 2), "utf8");
+    console.log(`    Exported ${jsonFilePath}.`);
+
+    return result.rows;
+  } catch (error) {
+    console.error(`    Error fetching ${fileName}:`, error);
+    return [];
+  }
+};
+
+// Exports final results
+const createFinalResults = async (data) => {
+  // Helper function to validate whether participants are valid (tnam is accurate)
+  const validateParticipants = (_data) => {
+    const reducedData = _data.reduce((acc, row) => {
+      const { eth_address, eth_amount, nam_amount, sig_hash } = row;
+      const nam_address_lc = row.nam_address.toLowerCase();
+
+      // Check for missing nam_address
+      if (!nam_address_lc || sig_hash === null) {
+        console.log(`      ⏩  Skipped ${eth_address}`);
+        switch (true) {
+          case !nam_address_lc && sig_hash === null:
+            console.log(
+              `          Reason: missing tnam address and signature hash.`
+            );
+            break;
+          case !nam_address_lc:
+            console.log(`          Reason: missing tnam address.`);
+            break;
+          case sig_hash === null:
+            console.log(`          Reason: missing signature hash.`);
+            break;
+          default:
+        }
+
+        return acc; // Skip this row if nam_address is missing or sig hash is null
+      }
+
+      if (!acc[nam_address_lc]) {
+        acc[nam_address_lc] = {
+          nam_address: nam_address_lc,
+          eth_amount: 0,
+          nam_amount: 0,
+        };
+      }
+
+      acc[nam_address_lc].eth_amount += parseFloat(eth_amount);
+      acc[nam_address_lc].nam_amount += parseFloat(nam_amount);
+
+      return acc;
+    }, {});
+
+    return Object.values(reducedData);
+  };
+
+  // Helper function to (interactively) validate the eth amounts
+  const validateEthAmounts = async (_data) => {
+    for (const row of _data) {
+      const { nam_address } = row;
+
+      const fixedEthAmount = row.eth_amount.toFixed(6);
+      if (fixedEthAmount > maxEthPerAddress) {
+        console.log(`      ❔  About ${nam_address}`);
+        const response = await askUser(
+          `Issue: ${fixedEthAmount}E exceeds ${maxEthPerAddress}E. Would you like to cap this to ${maxEthPerAddress}E?`,
+          true,
+          5
+        );
+        if (response) {
+          console.log(
+            `          Solution: ✏️  Capped to ${maxEthPerAddress}E.`
+          );
+          row.nam_amount = Math.round(
+            (row.nam_amount / row.eth_amount) * maxEthPerAddress
+          );
+          row.eth_amount = maxEthPerAddress;
+          continue;
+        } else {
+          console.log(`          Solution: 🔹  Kept on ${row.eth_amount}E.`);
+        }
+      } else if (fixedEthAmount < minEthPerAddress) {
+        console.log(`      ❔  About ${nam_address}`);
+        const response = await askUser(
+          `Issue: ${fixedEthAmount}E is less than the min. required amount of ${minEthPerAddress}E. Would you like to exclude this participant?`,
+          false,
+          5
+        );
+        if (response) {
+          console.log(`          Solution: ❌  Excluded ${nam_address}.`);
+          // exclude this address from the array by first marking the address as null
+          row.nam_address = null;
+          continue;
+        } else {
+          console.log(`          Solution: 🔹  Kept ${nam_address}.`);
+        }
+      }
+
+      row.nam_amount = Math.round(row.nam_amount);
+      row.eth_amount = fixedEthAmount;
+    }
+
+    // Remove those addresses that are marked as not having donated enough
+    return _data.filter((row) => row.nam_address !== null);
+  };
+
+  if (!data.length) return;
+
+  const filteredRows = await validateEthAmounts(validateParticipants(data));
+
+  const fileName = `result_${[
+    !excludeEligibles ? "eligibles" : "",
+    !excludeAboveCap ? "above_cap" : "",
+    !excludeNotInDb ? "not_in_db" : "",
+  ]
+    .filter((str) => str !== "")
+    .join("+")}`;
+
+  // .csv export
+  const csvFilePath = `./output/${fileName}.csv`;
+  await writeFile(
+    csvFilePath,
+    createCsv(["nam_address", "eth_amount", "nam_amount"], filteredRows),
+    "utf8"
+  );
+  console.log(`    Exported ${csvFilePath}.`);
+
+  // .json export
+  const jsonFilePath = `./output/${fileName}.json`;
+  await writeFile(jsonFilePath, JSON.stringify(filteredRows, null, 2), "utf8");
+  console.log(`    Exported ${jsonFilePath}.`);
+
+  // .proposal.json export
+  const proposalJsonFilePath = `./output/${fileName}.proposal.json`;
+  await writeFile(
+    proposalJsonFilePath,
+    JSON.stringify(
+      filteredRows.map((row) => {
+        return {
+          Internal: {
+            amount: Math.floor(row.nam_amount * 1e6).toString(),
+            target: row.nam_address.toLowerCase().trim(),
+          },
+        };
+      }),
+      null,
+      2
+    ),
+    "utf8"
+  );
+  console.log(`    Exported ${proposalJsonFilePath}.`);
+
+  return filteredRows;
+};
+
+main().catch((error) => {
+  console.error("Error occurred:", error);
+  process.exit(1);
+});

--- a/result.mjs
+++ b/result.mjs
@@ -1,6 +1,6 @@
 import { mkdir, rm, writeFile } from "fs/promises";
 import { pool } from "./lib/db.mjs";
-import { askUser, createCsv } from "./helpers.mjs";
+import { askUser, createCsvContent } from "./helpers.mjs";
 
 // Arguments
 // TODO: issue #15 will make the args --min-eth-per-address and --max-eth-per-address obsolete.
@@ -49,13 +49,13 @@ const main = async () => {
     `--clean: ${clean.toString()} [discards ./output before exporting results]`
   );
   console.log();
-
   console.log(
     `This will export the raw and final results in .csv, .json, and .proposal.json-format.`
   );
-  const response = await askUser("Do you wish to continue?");
 
-  if (!response) {
+  // Prompt user whether to continue or not
+  const answer = await askUser("Do you wish to continue?");
+  if (!answer) {
     console.log("Operation cancelled.");
     process.exit(0); // Exit the script if the user does not confirm
   }
@@ -76,47 +76,33 @@ const main = async () => {
   // Ensure ./output directory exists
   await mkdir("./output", { recursive: true });
 
+  console.log();
+
   // Create raw exports and collect all entries for later use
   console.log("💾  Saving raw results...");
   const allRows = [];
   await Promise.all(
     Object.entries(queries).map(async ([key, query]) => {
-      const data = await createRawResults(query, `_raw_${key}`);
+      const data = await createRawResult(query, `_raw_${key}`);
 
       if (data) allRows.push(...data);
     })
   );
 
+  console.log();
+
   // Create final results
   console.log("💾  Saving final results...");
-  const results = await createFinalResults(allRows);
+  const result = await createFinalResult(allRows);
 
-  showResults(results);
+  showFinalResult(result);
 
   // Close DB connection
   await pool.end();
 };
 
-const showResults = (data) => {
-  console.log();
-  console.log("🧮 Export finished successfully!");
-  console.log(`    👤 ${data.length} participants`);
-
-  let ethTotal = 0;
-  let namTotal = 0;
-
-  for (const row of data) {
-    ethTotal += parseFloat(row.eth_amount);
-    namTotal += row.nam_amount;
-  }
-  console.log(
-    `    💰 ${ethTotal.toFixed(6)} ETH donated (rounded by 6 decimals)`
-  );
-  console.log(`    👛 ${namTotal} NAM (rounded)`);
-};
-
 // Exports raw data and returns the rows as an object for later use
-const createRawResults = async (query, fileName) => {
+const createRawResult = async (query, fileName) => {
   try {
     const result = await pool.query(query);
 
@@ -129,7 +115,11 @@ const createRawResults = async (query, fileName) => {
 
     // raw .csv export
     const csvFilePath = `./output/${fileName}.csv`;
-    await writeFile(csvFilePath, createCsv(columns, result.rows), "utf8");
+    await writeFile(
+      csvFilePath,
+      createCsvContent(columns, result.rows),
+      "utf8"
+    );
     console.log(`    Exported ${csvFilePath}.`);
 
     // raw .json export
@@ -145,23 +135,23 @@ const createRawResults = async (query, fileName) => {
 };
 
 // Exports final results
-const createFinalResults = async (data) => {
-  // Helper function to validate whether participants are valid (tnam is accurate)
-  const validateParticipants = (_data) => {
+const createFinalResult = async (data) => {
+  // Helper function to group the participants by tnam-address and filter out invalid tnams.
+  const aggregateByNamAddress = (_data) => {
     const reducedData = _data.reduce((acc, row) => {
       const { eth_address, eth_amount, nam_amount, sig_hash } = row;
-      const nam_address_lc = row.nam_address.toLowerCase();
+      const nam_address = row.nam_address.toLowerCase();
 
       // Check for missing nam_address
-      if (!nam_address_lc || sig_hash === null) {
+      if (!nam_address || sig_hash === null) {
         console.log(`      ⏩  Skipped ${eth_address}`);
         switch (true) {
-          case !nam_address_lc && sig_hash === null:
+          case !nam_address && sig_hash === null:
             console.log(
               `          Reason: missing tnam address and signature hash.`
             );
             break;
-          case !nam_address_lc:
+          case !nam_address:
             console.log(`          Reason: missing tnam address.`);
             break;
           case sig_hash === null:
@@ -173,16 +163,16 @@ const createFinalResults = async (data) => {
         return acc; // Skip this row if nam_address is missing or sig hash is null
       }
 
-      if (!acc[nam_address_lc]) {
-        acc[nam_address_lc] = {
-          nam_address: nam_address_lc,
+      if (!acc[nam_address]) {
+        acc[nam_address] = {
+          nam_address,
           eth_amount: 0,
           nam_amount: 0,
         };
       }
 
-      acc[nam_address_lc].eth_amount += parseFloat(eth_amount);
-      acc[nam_address_lc].nam_amount += parseFloat(nam_amount);
+      acc[nam_address].eth_amount += parseFloat(eth_amount);
+      acc[nam_address].nam_amount += parseFloat(nam_amount);
 
       return acc;
     }, {});
@@ -190,60 +180,70 @@ const createFinalResults = async (data) => {
     return Object.values(reducedData);
   };
 
-  // Helper function to (interactively) validate the eth amounts
+  // Helper function to (interactively) validate the eth amounts.
   const validateEthAmounts = async (_data) => {
     for (const row of _data) {
       const { nam_address } = row;
 
       const fixedEthAmount = row.eth_amount.toFixed(6);
-      if (fixedEthAmount > maxEthPerAddress) {
-        console.log(`      ❔  About ${nam_address}`);
-        const response = await askUser(
-          `Issue: ${fixedEthAmount}E exceeds ${maxEthPerAddress}E. Would you like to cap this to ${maxEthPerAddress}E?`,
-          true,
-          5
-        );
-        if (response) {
-          console.log(
-            `          Solution: ✏️  Capped to ${maxEthPerAddress}E.`
+
+      switch (true) {
+        // participant exceeds max amount that's allowed to donate
+        case fixedEthAmount > maxEthPerAddress:
+          console.log(`      ❔  About ${nam_address}`);
+          const capParticipant = await askUser(
+            `Issue: ${fixedEthAmount}E exceeds ${maxEthPerAddress}E. Would you like to cap this participant to ${maxEthPerAddress}E?`,
+            true,
+            5
           );
-          row.nam_amount = Math.round(
-            (row.nam_amount / row.eth_amount) * maxEthPerAddress
+          if (capParticipant) {
+            console.log(
+              `          Solution: ✏️  Capped to ${maxEthPerAddress}E.`
+            );
+            row.nam_amount = Math.round(
+              (row.nam_amount / row.eth_amount) * maxEthPerAddress
+            );
+            row.eth_amount = maxEthPerAddress;
+            continue;
+          } else {
+            console.log(`          Solution: 🔹  Kept on ${fixedEthAmount}E.`);
+          }
+          break;
+        // participant is lower than the min amount that's allowed to donate
+        case fixedEthAmount < minEthPerAddress:
+          console.log(`      ❔  About ${nam_address}`);
+          const excludeParticipant = await askUser(
+            `Issue: ${fixedEthAmount}E is less than the min. required amount of ${minEthPerAddress}E. Would you like to exclude this participant?`,
+            false,
+            5
           );
-          row.eth_amount = maxEthPerAddress;
-          continue;
-        } else {
-          console.log(`          Solution: 🔹  Kept on ${row.eth_amount}E.`);
-        }
-      } else if (fixedEthAmount < minEthPerAddress) {
-        console.log(`      ❔  About ${nam_address}`);
-        const response = await askUser(
-          `Issue: ${fixedEthAmount}E is less than the min. required amount of ${minEthPerAddress}E. Would you like to exclude this participant?`,
-          false,
-          5
-        );
-        if (response) {
-          console.log(`          Solution: ❌  Excluded ${nam_address}.`);
-          // exclude this address from the array by first marking the address as null
-          row.nam_address = null;
-          continue;
-        } else {
-          console.log(`          Solution: 🔹  Kept ${nam_address}.`);
-        }
+          if (excludeParticipant) {
+            console.log(`          Solution: ❌  Excluded ${nam_address}.`);
+            // exclude this address from the array by marking the address as null
+            row.nam_address = null;
+            continue;
+          } else {
+            console.log(`          Solution: 🔹  Kept ${nam_address}.`);
+          }
+          break;
+        default:
       }
 
+      // Rounding prevents floating precision issues (TODO: to make this super precise we should consider using BigInts)
       row.nam_amount = Math.round(row.nam_amount);
       row.eth_amount = fixedEthAmount;
     }
 
-    // Remove those addresses that are marked as not having donated enough
+    // Remove addresses that are marked as not having donated enough
     return _data.filter((row) => row.nam_address !== null);
   };
 
   if (!data.length) return;
 
-  const filteredRows = await validateEthAmounts(validateParticipants(data));
+  // Process data coming from the raw exports
+  const filteredRows = await validateEthAmounts(aggregateByNamAddress(data));
 
+  // Filename for end result files
   const fileName = `result_${[
     !excludeEligibles ? "eligibles" : "",
     !excludeAboveCap ? "above_cap" : "",
@@ -256,7 +256,7 @@ const createFinalResults = async (data) => {
   const csvFilePath = `./output/${fileName}.csv`;
   await writeFile(
     csvFilePath,
-    createCsv(["nam_address", "eth_amount", "nam_amount"], filteredRows),
+    createCsvContent(["nam_address", "eth_amount", "nam_amount"], filteredRows),
     "utf8"
   );
   console.log(`    Exported ${csvFilePath}.`);
@@ -287,6 +287,24 @@ const createFinalResults = async (data) => {
   console.log(`    Exported ${proposalJsonFilePath}.`);
 
   return filteredRows;
+};
+
+const showFinalResult = (data) => {
+  console.log();
+  console.log("🧮 Export finished successfully!");
+  console.log(`    👤 ${data.length} participants`);
+
+  let ethTotal = 0;
+  let namTotal = 0;
+
+  for (const row of data) {
+    ethTotal += parseFloat(row.eth_amount);
+    namTotal += row.nam_amount;
+  }
+  console.log(
+    `    💰 ${ethTotal.toFixed(6)} ETH recognized (rounded by 6 decimals)`
+  );
+  console.log(`    👛 ${namTotal} NAM (rounded)`);
 };
 
 main().catch((error) => {


### PR DESCRIPTION
Fixes #31 and #32. This is an excerpt from the README:

## Results

The results are built from three different categories:

- (1) List of _eligible users_
- (2) List of users who donated _after the cap got reached_
- (3) List of users who _initially weren't included due to mistakes made_, but got corrected using [A.2 Rescue plan](#a2-rescue-plan)

There are two ways one could export these results. Either [_by using the wizard_](#i-using-the-wizard-recommended) or [_by using PSQL_](#ii-using-psql).

### I. Using the wizard _(recommended)_

#### Command
The following command can be used to export the raw and final (merged) results in .csv, .json and .proposal.json-format:

```
node result.mjs
```

#### Arguments _(optional)_

- `--exclude-eligibles`: excludes eligible users
- `--exclude-above-cap`: excludes users who donated after the cap
- `--exclude-not-in-db`: excludes users who were initially not included
- `--min-eth-per-address x`: the minimum amount of ETH a participant is required to have donated
  - _default value_: `0.03`
- `--max-eth-per-address y`: the maximum amount of ETH a participant was allowed to donate
  - _default value_: `0.3`
- `--clean`: this will clean the ./output folder before exporting the results

#### Features
- Exports .csv, .json and .proposal.json files.
- Saves _raw_ exports from the views:
  - _private_result_eligible_addresses_finalized_in_db_ as  `_raw_eligibles` (1),
  - _private_result_above_cap_addresses_in_db_ as `_raw_above_cap` (2) and
  - _private_result_addresses_not_in_db_ as `_raw_not_in_db` (3).
- Merges the results together by grouping the results by _tnam address_. This makes sure each participant will only be included once in the .proposal.json file.
- Gives the user a heads up whenever a participant gets skipped due to a _missing tnam address_ or _signature hash_.
- Asks the user whether to _cap a tnam address' ETH amount_ if the resulting value _is higher than_ the set `--max-eth-per-address`.
- Asks the user whether to _exclude a tnam address_ if this participant's resulting donation amount _is lower than_ the set `--min-eth-per-address`.

### II. Using PSQL
This route requires more manual work as it will only get you the _raw_ .csv files (which are also exported when _using the wizard_). If for some reason you're unable to use `node` or you only have direct access to the SQL database, use these commands:
- _private_result_eligible_addresses_finalized_in_db_ as  `_raw_eligibles.csv` (1)

  ```sql
  copy(SELECT from_address AS eth_address, tnam AS nam_address, eligible_amount AS eth_amount, suggested_nam AS nam_amount FROM private_result_eligible_addresses_finalized_in_db) To '/var/lib/postgresql/_raw_eligibles.csv' With CSV DELIMITER ',' HEADER;
  ```

- _private_result_above_cap_addresses_in_db_ as `_raw_above_cap.csv` (2)

  ```sql
  copy(SELECT from_address AS eth_address, tnam AS nam_address, eligible_above_cap AS eth_amount, suggested_nam AS nam_amount FROM private_result_above_cap_addresses_in_db) To '/var/lib/postgresql/_raw_above_cap.csv' With CSV DELIMITER ',' HEADER;
  ```

- _private_result_addresses_not_in_db_ as `_raw_not_in_db.csv` (3)

  ```sql
  copy(SELECT from_address AS eth_address, tnam AS nam_address, total_eth AS eth_amount, suggested_nam AS nam_amount, sig_hash FROM private_result_addresses_not_in_db) To '/var/lib/postgresql/_raw_not_in_db.csv' With CSV DELIMITER ',' HEADER;
  ```
