### PR TITLE
Implemented solution 2 for #34

### DIFF
--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -11,11 +11,10 @@ async function withRetry(operation, identifier, options = {}, retryCount = 0) {
   options = {
     baseDelay: 1000,
     maxRetries: 20,
-    propagateError: true,
     ...options,
   };
 
-  const { baseDelay, maxRetries, propagateError } = options;
+  const { baseDelay, maxRetries } = options;
 
   try {
     return await operation();
@@ -37,9 +36,6 @@ async function withRetry(operation, identifier, options = {}, retryCount = 0) {
     logError(
       `Failed to complete operation for ${identifier} after ${maxRetries} attempts: ${error.message}`
     );
-
-    // If we pass down the option { propogateError: false } then we won't propogate any errors (useful for silent error-handling - see solution 1 in #34)
-    if (!propagateError) return null;
 
     throw error;
   }

--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -154,10 +154,12 @@ export async function getFinalizedTransactions(startBlock, endBlock) {
   const result = { transactions: [], lastSuccessfulBlock: null };
   log(`Processing block ${startBlock} - ${endBlock}...`);
 
-  const batchResults = await Promise.all(
-    [...Array(endBlock - startBlock + 1)].map((_, i) =>
-      getBlockTransactions(startBlock + i, false)
-    )
+  const blockNumbers = [...Array(endBlock - startBlock + 1)].map(
+    (_, i) => startBlock + i
+  );
+
+  const batchResults = await Promise.allSettled(
+    blockNumbers.map((blockNumber) => getBlockTransactions(blockNumber, false))
   );
 
   // Find the first `null` and slice off the elements after it

--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -158,7 +158,7 @@ export async function getFinalizedTransactions(startBlock, endBlock) {
     (_, i) => startBlock + i
   );
 
-  const batchResults = await Promise.allSettled(
+  const batchResults = await Promise.all(
     blockNumbers.map((blockNumber) => getBlockTransactions(blockNumber, false))
   );
 

--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -79,52 +79,42 @@ export async function getTransactionReceipt(txHash) {
 }
 
 export const getBlockTransactions = async (blockNumber, finalized = false) => {
-  return withRetry(
-    async () => {
-      const response = await axios.post(
-        `${INFURA_BASE_URL}/${INFURA_API_KEY}`,
-        {
-          jsonrpc: "2.0",
-          method: "eth_getBlockByNumber",
-          params: [
-            finalized ? "finalized" : `0x${blockNumber.toString(16)}`,
-            true,
-          ],
-          id: 1,
-        }
-      );
+  return withRetry(async () => {
+    const response = await axios.post(`${INFURA_BASE_URL}/${INFURA_API_KEY}`, {
+      jsonrpc: "2.0",
+      method: "eth_getBlockByNumber",
+      params: [finalized ? "finalized" : `0x${blockNumber.toString(16)}`, true],
+      id: 1,
+    });
 
-      const block = response.data.result;
+    const block = response.data.result;
 
-      if (!block) {
-        if (VERBOSE_LOGGING) log(`Block ${blockNumber}: doesn't exist.`);
+    if (!block) {
+      if (VERBOSE_LOGGING) log(`Block ${blockNumber}: doesn't exist.`);
+      return null;
+    }
+
+    if (finalized) {
+      const finalizedBlock = parseInt(block.number, 16);
+
+      if (finalizedBlock > blockNumber) {
+        // If the finalized block is greater than the latest polled block, it means that we missed this block, so call the function again with the latest block number.
+        return await getBlockTransactions(blockNumber, false);
+      }
+
+      if (blockNumber > finalizedBlock) {
+        // If the polled block is greater than the finalized block, we should not continue.
+        if (VERBOSE_LOGGING) log(`Block ${blockNumber}: not finalized yet.`);
         return null;
       }
+    }
 
-      if (finalized) {
-        const finalizedBlock = parseInt(block.number, 16);
+    const transactions = block.transactions
+      .filter((tx) => tx.to?.toLowerCase() === ADDRESS.toLowerCase())
+      .map((tx) => formatTransaction(tx, block.timestamp));
 
-        if (finalizedBlock > blockNumber) {
-          // If the finalized block is greater than the latest polled block, it means that we missed this block, so call the function again with the latest block number.
-          return await getBlockTransactions(blockNumber, false);
-        }
-
-        if (blockNumber > finalizedBlock) {
-          // If the polled block is greater than the finalized block, we should not continue.
-          if (VERBOSE_LOGGING) log(`Block ${blockNumber}: not finalized yet.`);
-          return null;
-        }
-      }
-
-      const transactions = block.transactions
-        .filter((tx) => tx.to?.toLowerCase() === ADDRESS.toLowerCase())
-        .map((tx) => formatTransaction(tx, block.timestamp));
-
-      return transactions;
-    },
-    `block ${blockNumber}`,
-    { propagateError: false }
-  );
+    return transactions;
+  }, `block ${blockNumber}`);
 };
 
 export async function addReceiptsTo(transactions, batchSize = 50) {
@@ -152,36 +142,32 @@ export async function addReceiptsTo(transactions, batchSize = 50) {
 
 export async function getFinalizedTransactions(startBlock, endBlock) {
   const result = { transactions: [], lastSuccessfulBlock: null };
-  log(`Processing block ${startBlock} - ${endBlock}...`);
+  log(`Processing blocks ${startBlock} - ${endBlock}...`);
 
-  const blockNumbers = [...Array(endBlock - startBlock + 1)].map(
+  // Generate block numbers to query
+  const blockNumbers = Array.from(
+    { length: endBlock - startBlock + 1 },
     (_, i) => startBlock + i
   );
 
-  const batchResults = await Promise.all(
+  // Fetch transactions for all blocks in parallel
+  const batchResults = await Promise.allSettled(
     blockNumbers.map((blockNumber) => getBlockTransactions(blockNumber, false))
   );
 
-  // Find the first `null` and slice off the elements after it
-  const firstNullIndex = batchResults.findIndex((txs) => txs === null);
+  // Collect transactions until a block retrieval fails or block is not finalized/non-existent
+  for (const [i, entry] of batchResults.entries()) {
+    const transactions = entry.status === "fulfilled" ? entry.value : null;
+    const blockNumber = startBlock + i;
 
-  // if a null is found, we should stop, cause a block failed to retrieve values
-  if (firstNullIndex !== -1) {
-    batchResults.slice(0, firstNullIndex).forEach((txs) => {
-      result.transactions.push(...txs);
-    });
+    if (transactions === null) {
+      result.lastSuccessfulBlock = blockNumber - 1;
+      break;
+    }
 
-    result.lastSuccessfulBlock = startBlock + firstNullIndex - 1;
-
-    return result;
+    result.transactions.push(...transactions);
+    result.lastSuccessfulBlock = blockNumber;
   }
-
-  // Add all transactions from the batch if they all succeeded
-  batchResults.forEach((txs) => {
-    result.transactions.push(...txs);
-  });
-
-  result.lastSuccessfulBlock = endBlock;
 
   return result;
 }

--- a/lib/infura.mjs
+++ b/lib/infura.mjs
@@ -7,30 +7,40 @@ import {
 } from "../_variables.mjs";
 import { log, logError } from "../helpers.mjs";
 
-const BASE_DELAY = 1000;
-const MAX_RETRIES = 20;
+async function withRetry(operation, identifier, options = {}, retryCount = 0) {
+  options = {
+    baseDelay: 1000,
+    maxRetries: 20,
+    propagateError: true,
+    ...options,
+  };
 
-async function withRetry(operation, identifier, retryCount = 0) {
+  const { baseDelay, maxRetries, propagateError } = options;
+
   try {
     return await operation();
   } catch (error) {
-    if (retryCount < MAX_RETRIES) {
-      const delay = BASE_DELAY * Math.pow(2, retryCount); // Exponential backoff
+    if (retryCount < maxRetries) {
+      const delay = baseDelay * Math.pow(2, retryCount); // Exponential backoff
       const errorMessage =
         error.response?.data?.error?.message || error.message;
       logError(
         `Attempt ${
           retryCount + 1
-        }/${MAX_RETRIES} failed for ${identifier}. Error: ${errorMessage}. Retrying in ${delay}ms...`
+        }/${maxRetries} failed for ${identifier}. Error: ${errorMessage}. Retrying in ${delay}ms...`
       );
 
       await new Promise((resolve) => setTimeout(resolve, delay));
-      return withRetry(operation, identifier, retryCount + 1);
+      return withRetry(operation, identifier, options, retryCount + 1);
     }
 
     logError(
-      `Failed to complete operation for ${identifier} after ${MAX_RETRIES} attempts: ${error.message}`
+      `Failed to complete operation for ${identifier} after ${maxRetries} attempts: ${error.message}`
     );
+
+    // If we pass down the option { propogateError: false } then we won't propogate any errors (useful for silent error-handling - see solution 1 in #34)
+    if (!propagateError) return null;
+
     throw error;
   }
 }
@@ -69,54 +79,55 @@ export async function getTransactionReceipt(txHash) {
 }
 
 export const getBlockTransactions = async (blockNumber, finalized = false) => {
-  return withRetry(async () => {
-    const response = await axios.post(`${INFURA_BASE_URL}/${INFURA_API_KEY}`, {
-      jsonrpc: "2.0",
-      method: "eth_getBlockByNumber",
-      params: [finalized ? "finalized" : `0x${blockNumber.toString(16)}`, true],
-      id: 1,
-    });
+  return withRetry(
+    async () => {
+      const response = await axios.post(
+        `${INFURA_BASE_URL}/${INFURA_API_KEY}`,
+        {
+          jsonrpc: "2.0",
+          method: "eth_getBlockByNumber",
+          params: [
+            finalized ? "finalized" : `0x${blockNumber.toString(16)}`,
+            true,
+          ],
+          id: 1,
+        }
+      );
 
-    const block = response.data.result;
+      const block = response.data.result;
 
-    if (!block) {
-      if (VERBOSE_LOGGING) log(`Block ${blockNumber}: doesn't exist.`);
-      return null;
-    }
-
-    if (finalized) {
-      const finalizedBlock = parseInt(block.number, 16);
-
-      if (finalizedBlock > blockNumber) {
-        // If the finalized block is greater than the latest polled block, it means that we missed this block, so call the function again with the latest block number.
-        return await getBlockTransactions(blockNumber, false);
-      }
-
-      if (blockNumber > finalizedBlock) {
-        // If the polled block is greater than the finalized block, we should not continue.
-        if (VERBOSE_LOGGING) log(`Block ${blockNumber}: not finalized yet.`);
+      if (!block) {
+        if (VERBOSE_LOGGING) log(`Block ${blockNumber}: doesn't exist.`);
         return null;
       }
-    }
 
-    const transactions = block.transactions
-      .filter((tx) => tx.to?.toLowerCase() === ADDRESS.toLowerCase())
-      .map((tx) => formatTransaction(tx, block.timestamp));
+      if (finalized) {
+        const finalizedBlock = parseInt(block.number, 16);
 
-    return transactions;
-  }, `block ${blockNumber}`);
+        if (finalizedBlock > blockNumber) {
+          // If the finalized block is greater than the latest polled block, it means that we missed this block, so call the function again with the latest block number.
+          return await getBlockTransactions(blockNumber, false);
+        }
+
+        if (blockNumber > finalizedBlock) {
+          // If the polled block is greater than the finalized block, we should not continue.
+          if (VERBOSE_LOGGING) log(`Block ${blockNumber}: not finalized yet.`);
+          return null;
+        }
+      }
+
+      const transactions = block.transactions
+        .filter((tx) => tx.to?.toLowerCase() === ADDRESS.toLowerCase())
+        .map((tx) => formatTransaction(tx, block.timestamp));
+
+      return transactions;
+    },
+    `block ${blockNumber}`,
+    { propagateError: false }
+  );
 };
 
 export async function addReceiptsTo(transactions, batchSize = 50) {
-  // Left this here in case we want to return to this approach without batching.
-  // return await Promise.all(
-  //   filteredTransactions
-  //     .map(async (tx) => {
-  //       const receipt = await getTransactionReceipt(tx.hash);
-  //       return addReceipt(tx, receipt);
-  //     })
-  // );
-
   const result = [];
 
   for (let i = 0; i < transactions.length; i += batchSize) {


### PR DESCRIPTION
Solution 2 makes sure not to let the entire batch fail by handling propagated errors (rejected promises) in the `getFinalizedTransactions` function.

The logic is to make sure to collect all the transactions up till the block that failed.